### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -35,7 +35,7 @@ class syntax_plugin_sugar extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addSpecialPattern('~~SugarContact:[-0-9a-f]+~~', $mode, 'plugin_sugar');    
     }
 
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         $data = array();
         // trim the ~~ characters
         $match_clean = trim($match, "~");
@@ -71,7 +71,7 @@ class syntax_plugin_sugar extends DokuWiki_Syntax_Plugin {
         return $data;
     }
 
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if ( $mode == 'xhtml' ) {
 		$renderer->externallink( $data[0],$data[1]);
                 return true;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
